### PR TITLE
ASM-6513 Cleanup prior to deleting LUN

### DIFF
--- a/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
+++ b/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
@@ -264,22 +264,25 @@ Puppet::Type.type(:vnx_storagegroup).provide(:vnx_storagegroup) do
     end
   end
 
+  def disconnect_host
+    run(["storagegroup", "-disconnecthost", "-host", resource[:host_name], "-gname", resource[:sg_name], "-o"])
+  end
+
+  def destroy_empty_sg
+    temp = run(["storagegroup","-list","-host","-gname", resource[:sg_name]])
+    host_list = []
+    temp.each_line do |s|
+      host_list << s.split("Host name:")[1].to_s.strip unless  host_list.include?(s.split("Host name:")[1].to_s.strip)
+    end
+    host_list = host_list.reject{|s| s.empty?}
+    run(["storagegroup", "-destroy", "-gname", resource[:sg_name], "-o"]) if host_list.empty?
+  end
+
   def flush
     # destroy
     if @property_flush[:ensure] == :absent
-
-      if resource[:host_name]
-        run(["storagegroup", "-disconnecthost", "-host", resource[:host_name], "-gname", resource[:sg_name], "-o"])
-      end
-      temp = run(["storagegroup","-list","-host","-gname", resource[:sg_name]])
-      k=[]
-      temp.split(/\n/).each do |s|
-        k << s.split("Host name:")[1].to_s.strip unless  k.include?(s.split("Host name:")[1].to_s.strip)
-      end
-      k= k.reject{|s| s.empty?}
-      if k.empty?
-        run(["storagegroup", "-destroy", "-gname", resource[:sg_name], "-o"])
-      end
+      disconnect_host if resource[:host_name]
+      destroy_empty_sg if resource[:sg_name]
       @property_hash[:ensure] = :absent
       return
     end

--- a/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
+++ b/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
@@ -267,7 +267,19 @@ Puppet::Type.type(:vnx_storagegroup).provide(:vnx_storagegroup) do
   def flush
     # destroy
     if @property_flush[:ensure] == :absent
-      run(["storagegroup", "-destroy", "-gname", resource[:sg_name], "-o"])
+
+      if resource[:host_name]
+        run(["storagegroup", "-disconnecthost", "-host", resource[:host_name], "-gname", resource[:sg_name], "-o"])
+      end
+      temp = run(["storagegroup","-list","-host","-gname", resource[:sg_name]])
+      k=[]
+      temp.split(/\n/).each do |s|
+        k << s.split("Host name:")[1].to_s.strip unless  k.include?(s.split("Host name:")[1].to_s.strip)
+      end
+      k= k.reject{|s| s.empty?}
+      if k.empty?
+        run(["storagegroup", "-destroy", "-gname", resource[:sg_name], "-o"])
+      end
       @property_hash[:ensure] = :absent
       return
     end


### PR DESCRIPTION
Before deleting the LUN we need to remove it from the storage
group. Also disconnect any hosts from the storage group prior to
deleting. Delete the storage group entirely if it is empty.
