### PR TITLE
VNX lun supporting other sizes(KB, MB, GB, TB)

### DIFF
--- a/lib/puppet/type/vnx_lun.rb
+++ b/lib/puppet/type/vnx_lun.rb
@@ -44,8 +44,10 @@ Puppet::Type.newtype(:vnx_lun) do
 
   newproperty(:capacity) do
     desc "The LUN capacity"
-    munge do |value|
-      value.to_i
+    validate do |value|
+      unless value =~ /^\d+([mgt]$|(MB|GB|TB)$)/
+       	raise ArgumentError, '%s is not a valid volume size.' % value
+      end
     end
   end
 


### PR DESCRIPTION
By default size is in GBs. If we want to create a LUN in other sizes, we need to specify it in sq variable. It accepts gb, mb, kb.