### PR TITLE
ASM-Vnxluncompression

### DIFF
--- a/lib/puppet/type/vnx_lun.rb
+++ b/lib/puppet/type/vnx_lun.rb
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:vnx_lun) do
 
   newparam(:type) do
     desc "LUN type, THIN or Thick. Unchangeable once created."
-    newvalues(:thin, :nonthin, :snap)
+    newvalues(:thin, :nonthin, :snap, :compressed)
   end
 
   newproperty(:capacity) do


### PR DESCRIPTION
Letting LUN type to accept "compressed". 
When you pass lun type as compressed, it creates 'thin' LUN with
compression enabled.   