### PR TITLE
ASM 7380 VNX lun supporting other sizes(KB, MB, GB, TB)

### DIFF
--- a/lib/puppet/provider/vnx_lun/vnx_lun.rb
+++ b/lib/puppet/provider/vnx_lun/vnx_lun.rb
@@ -211,8 +211,9 @@ Puppet::Type.type(:vnx_lun).provide(:vnx_lun) do
     # expand
     args = ["lun", "-expand", "-name", resource[:lun_name]]
     origin_length = args.length
-    args << "-capacity" << resource[:capacity] if @property_flush[:capacity]
-    args << "-sq" << resource[:size_qual] if @property_flush[:size_qual]
+    capacity, units = size_to_sizequal(resource[:capacity]) if @property_flush[:capacity]
+    args << "-capacity" << capacity if capacity
+    args << "-sq" << units if units
     args << "-ignoreThresholds" if (resource[:ignore_thresholds] == :true)
     args << "-o"
     run(args) if args.length > origin_length + 1
@@ -247,6 +248,14 @@ Puppet::Type.type(:vnx_lun).provide(:vnx_lun) do
     run(args) if args.length > origin_length + 1
   end
 
+  def size_to_sizequal(size)
+    unless size.match /^(\d+)([mgt]$|(MB|GB|TB)$)/
+      raise ArgumentError, '%s is not a valid volume size.' % size
+    end
+    
+    return  Integer($1), $2.gsub!(/MB|GB|TB|m|g|t/, "m" => "mb", "g" => "gb", "t" => "tb", "MB" => "mb", "GB" => "gb", "TB" => "tb")
+  end
+
   def create_lun
     args = ['lun', '-create']
     if resource[:type] == :snap
@@ -260,7 +269,9 @@ Puppet::Type.type(:vnx_lun).provide(:vnx_lun) do
       args << "-allowInbandSnapAttach" << (resource[:allow_inband_snap_attach] == :true ? "yes" : "no") if resource[:allow_inband_snap_attach]
     else
       args << "-type" << (resource[:type] == :thin ? 'Thin' : 'NonThin') if resource[:type]
-      args << "-capacity" << resource[:capacity] if resource[:capacity]
+      capacity, units = size_to_sizequal(resource[:capacity]) if resource[:capacity]
+      args << "-capacity" << capacity if capacity
+      args << "-sq" << units if units
       args << "-poolId" << resource[:pool_id] if resource[:pool_id]
       args << "-poolName" << resource[:pool_name] if resource[:pool_name]
       args << "-sp" << resource[:default_owner].to_s.upcase if resource[:default_owner]

--- a/lib/puppet/type/vnx_lun.rb
+++ b/lib/puppet/type/vnx_lun.rb
@@ -44,8 +44,10 @@ Puppet::Type.newtype(:vnx_lun) do
 
   newproperty(:capacity) do
     desc "The LUN capacity"
-    munge do |value|
-      value.to_i
+    validate do |value|
+      unless value =~ /^\d+([mgt]$|(MB|GB|TB)$)/
+       	raise ArgumentError, '%s is not a valid volume size.' % value
+      end
     end
   end
 

--- a/lib/puppet/type/vnx_lun.rb
+++ b/lib/puppet/type/vnx_lun.rb
@@ -50,12 +50,7 @@ Puppet::Type.newtype(:vnx_lun) do
       end
     end
   end
-
-  newproperty(:size_qual) do
-    desc "Size qualifier for the LUN capacity"
-    newvalues(:gb, :tb, :mb, :bc)
-  end
-
+  
   newproperty(:pool_name) do
     desc "Storage pool the LUN will belong to. Unchangeable once created."
   end


### PR DESCRIPTION
By default size is in GBs. If we want to create a
LUN in MB, we need to specify it in sq variable. It
accepts gb, mb, kb.