### PR TITLE
ASM-7300 adding nonthin to facts

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -51,7 +51,7 @@ def addons_info(opts)
       snap = true if s.include?("snap")
     end
   end
-  facts = {'addons_data' => { 'addons' => [{'thin' => thin}, {'compression' => compression}, {'snap' => snap}]}}
+  facts = {'addons_data' => { 'addons' => [{'nonthin' => true}, {'thin' => thin}, {'compression' => compression}, {'snap' => snap}]}}
   facts
 end
 


### PR DESCRIPTION
Nonthin is available by default for every storage.
adding it to the addons_data, it could be used for
displaying dropdown in the template.