### PR TITLE
ASM-7554 Volume scale up and retry

### DIFF
--- a/spec/unit/provider/vnx_lun/vnx_lun_spec.rb
+++ b/spec/unit/provider/vnx_lun/vnx_lun_spec.rb
@@ -46,4 +46,13 @@ describe Puppet::Type.type(:vnx_lun).provider(:vnx_lun) do
       end
     end
   end
+
+  describe "#get_lun_capacity_mb" do
+    context "When you pass lun number" do
+      it "returns LUN capacity in Megabytes" do
+        provider.stubs(:run).returns("LUN Capacity(Megabytes): 10\nLUN Capacity(Blocks): 2048")
+        expect(provider.get_lun_capacity_mb).to eq(10)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If we retry a deployment it was running volume 
size expansion operation even the size is same as
old one.

VNX LUN expand operation works only if new size is
greater than old one.

I added condition to run expand operation only if 
new size is greater than old one.