### PR TITLE
ASM-7600 Disconnecting the host from storagegroup

### DIFF
--- a/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
+++ b/lib/puppet/provider/vnx_storagegroup/vnx_storagegroup.rb
@@ -266,17 +266,24 @@ Puppet::Type.type(:vnx_storagegroup).provide(:vnx_storagegroup) do
     end
   end
 
-  def disconnect_host
-    run(["storagegroup", "-disconnecthost", "-host", resource[:host_name], "-gname", resource[:sg_name], "-o"])
-  end
-
-  def destroy_empty_sg
+  def host_list
     temp = run(["storagegroup","-list","-host","-gname", resource[:sg_name]])
     host_list = []
     temp.each_line do |s|
       host_list << s.split("Host name:")[1].to_s.strip unless  host_list.include?(s.split("Host name:")[1].to_s.strip)
     end
-    host_list = host_list.reject{|s| s.empty?}
+    host_list.reject{|s| s.empty?}
+  end
+
+  def is_host_connected?
+    host_list.include?(resource[:host_name])
+  end
+
+  def disconnect_host
+    run(["storagegroup", "-disconnecthost", "-host", resource[:host_name], "-gname", resource[:sg_name], "-o"]) if is_host_connected?
+  end
+
+  def destroy_empty_sg
     run(["storagegroup", "-destroy", "-gname", resource[:sg_name], "-o"]) if host_list.empty?
   end
 

--- a/spec/unit/provider/vnx_storagegroup/vnx_storagegroup_spec.rb
+++ b/spec/unit/provider/vnx_storagegroup/vnx_storagegroup_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "rspec/expectations"
+
+describe Puppet::Type.type(:vnx_storagegroup).provider(:vnx_storagegroup) do
+  let(:resource) {Puppet::Type.type(:vnx_storagegroup).new(
+    {
+      :name     => "bs",
+      :sg_name => "Testsg",
+      :ensure   => "present",
+      :host_name => "testesxi"
+    }
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+  describe "#host_list" do
+    context "When you pass storagegroup" do
+      it "returns list of hosts connected to that storagegroup" do
+        provider.stubs(:run).returns("Host name: testhost")
+        expect(provider.host_list).to match_array(["testhost"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Running "disconnect" command will fail if host is not
connected

Adding a condition to run "disconnect" command  only 
if host is connected to storage group